### PR TITLE
fix file modes for future parser compatibility

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -49,7 +49,7 @@ define runit::service (
   # creating the logging sub-service, if requested
   if $logger == true {
     runit::service{ "${name}/log":
-      user => $user, group => $group, enable => false, ensure => $ensure, logger => false,
+      user    => $user, group => $group, enable => false, ensure => $ensure, logger => false,
       content => template('runit/logger_run.erb'),
     }
   }
@@ -74,7 +74,7 @@ define runit::service (
       },
       source  => $source,
       ensure  => $ensure,
-      mode    => 755,
+      mode    => '0755',
       ;
     "${svbase}/finish":
       content => $finish_source ? {
@@ -86,7 +86,7 @@ define runit::service (
       },
       source  => $finish_source,
       ensure  => $ensure,
-      mode    => 755,
+      mode    => '0755',
       ;
     "${svbase}/supervise":
       ensure => directory,

--- a/manifests/service/env.pp
+++ b/manifests/service/env.pp
@@ -37,7 +37,7 @@ define runit::service::env( $service, $envname = $title, $value, $ensure = prese
   }
 
   file { "${envdir}/${envname}":
-    ensure => $ensure,
+    ensure  => $ensure,
     content => "${value}\n",
     owner   => $user,
     group   => $group,


### PR DESCRIPTION
> Warning: Non-string values for the file mode property are deprecated. It must be a string, either a  symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.
    (at /usr/lib/ruby/vendor_ruby/puppet/type/file/mode.rb:69:in `block (2 levels) in 
 <module:Puppet>')
